### PR TITLE
Fix pages build output directory in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,3 @@
 name = "piyushsonar-in"
 compatibility_date = "2023-10-10"
-pages_build_output_dir = ".next"
+pages_build_output_dir = "out"


### PR DESCRIPTION
This pull request makes a small configuration update to the `wrangler.toml` file, changing the build output directory for the project. The output directory is now set to `out` instead of `.next`.